### PR TITLE
Improve query handling

### DIFF
--- a/google_search.py
+++ b/google_search.py
@@ -2,16 +2,19 @@
 Google Custom Search API implementation for Meep Research MCP
 """
 
-import aiohttp
-import asyncio
 import logging
+try:
+    import aiohttp
+except ImportError as e:
+    aiohttp = None
+    logging.error("aiohttp package is required for Google Custom Search")
+    raise
+import asyncio
 from typing import Dict, List, Any, Optional
 from urllib.parse import quote_plus
 import time
 import json
 from datetime import datetime, timedelta
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 try:
     from .config import get_config, ConfigError

--- a/search_strategies.py
+++ b/search_strategies.py
@@ -123,7 +123,12 @@ class QueryTranslator:
         
         # Combine all parts
         final_query = ' '.join(query_parts)
-        
+
+        # Fallback to the raw request if translation produced no operators
+        if not final_query.strip():
+            final_query = request
+            operator_breakdown['raw_request'] = request
+
         return SearchQuery(
             query=final_query,
             purpose=self._generate_purpose(request),

--- a/server.py
+++ b/server.py
@@ -64,7 +64,18 @@ async def search_with_operators(
     enhanced_query = build_advanced_query(query, search_type)
     
     # Validate and convert query for Google Custom Search
-    google_query = validate_and_convert_query(enhanced_query)
+    try:
+        google_query = validate_and_convert_query(enhanced_query)
+    except ValueError as ve:
+        logger.error(f"Invalid search query: {ve}")
+        return {
+            "results": [],
+            "enhanced_query": enhanced_query,
+            "converted_query": None,
+            "engine": "google_custom_search",
+            "error": str(ve),
+            "api_status": get_api_status(),
+        }
     
     try:
         # Perform search using Google Custom Search (uses max_results from config)


### PR DESCRIPTION
## Summary
- prevent empty query generation in `translate_research_query`
- return error when search query fails validation
- avoid failing imports by clearly requiring `aiohttp`

## Testing
- `python -m py_compile search_strategies.py google_search.py server.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a750516c83279a830a262f94999e